### PR TITLE
Fix deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
       - build:
           requires:
             - checkout_code


### PR DESCRIPTION
The deploy workflow should only execute only when a tag is associated 