### PR TITLE
fix: get npm stats from yesterday

### DIFF
--- a/src/shared/npm-stats/npm-stats.service.spec.ts
+++ b/src/shared/npm-stats/npm-stats.service.spec.ts
@@ -43,8 +43,8 @@ describe('NpmStatsService', () => {
       });
 
       it('should call \'getstats\' with the right start and end date', () => {
-        expect(npmAPI.from).toEqual(getDateOfXPassedDays(2));
-        expect(npmAPI.to).toEqual(getDateOfXPassedDays(1));
+        expect(npmAPI.from).toEqual(getDateOfXPassedDays(1));
+        expect(npmAPI.to).toEqual(getDateOfXPassedDays(0));
       });
     });
 

--- a/src/shared/npm-stats/npm-stats.service.ts
+++ b/src/shared/npm-stats/npm-stats.service.ts
@@ -30,7 +30,7 @@ export class NpmStatsService {
       subject.complete();
     };
 
-    npmAPI.getstat(slug, this.getDateOfXPassedDays(2), this.getDateOfXPassedDays(1), callback);
+    npmAPI.getstat(slug, this.getDateOfXPassedDays(1), this.getDateOfXPassedDays(0), callback);
 
     return subject.asObservable();
   }


### PR DESCRIPTION
There is a bug that the stats are gotten from two days ago.

![image](https://user-images.githubusercontent.com/7026066/56762181-e18cc380-6764-11e9-9e60-b0e54b74d22e.png)
![image](https://user-images.githubusercontent.com/7026066/56762254-0da84480-6765-11e9-8418-f08aaa84df1a.png)

The response should be 4 instead of 2 + 4

------------

Bot in development

![image](https://user-images.githubusercontent.com/7026066/56762582-cbcbce00-6765-11e9-949b-b8b6a909f6ce.png)


> Ref : [npm-stat.com](https://npm-stat.com/charts.html?package=ngx-sticky-directive&from=2019-04-23&to=2019-04-24)