### PR TITLE
ci(fix): optimize the node dependencies size on production

### DIFF
--- a/.circleci/deployment/deploy.sh
+++ b/.circleci/deployment/deploy.sh
@@ -32,7 +32,7 @@ function copy_files() {
 
 function install_dependencies() {
   echo "$log_prefix Installing dependencies";
-  ssh $remote_server_user@$remote_server_ip "docker run --rm -v $remote_server_path:/repo node:10.15-alpine /bin/ash -c 'cd /repo && yarn'";
+  ssh $remote_server_user@$remote_server_ip "docker run --rm -v $remote_server_path:/repo node:10.15-alpine /bin/ash -c 'cd /repo && yarn install --production=true'";
 }
 
 function start_project() {


### PR DESCRIPTION
Just install the dependencies needed for production.

The final size was optimized from 358MB to 51MB!

I test out by hand in the server verifying that this is not going to brake the deployment


--------------

Now we need to put the dependencies in the right place, we need to be conscious about that.