### PR TITLE
fix: handle the 403 error on sending message

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/express": "4.16.1",
     "@types/jest": "24.0.12",
     "@types/nedb": "1.8.7",
-    "@types/node": "10.14.6",
+    "@types/node": "12.0.0",
     "@types/node-cron": "2.0.2",
     "@types/node-telegram-bot-api": "0.31.0",
     "@types/supertest": "2.0.7",

--- a/src/telegram-bot/common/utils/utils.spec.ts
+++ b/src/telegram-bot/common/utils/utils.spec.ts
@@ -1,4 +1,8 @@
 import * as TelegramBot from 'node-telegram-bot-api';
+
+import { Observable, NEVER, Subscription } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
 import { sendMessageHTML } from './utils';
 
 describe('Utils', () => {
@@ -19,9 +23,7 @@ describe('Utils', () => {
 
     // spies
     beforeEach(() => {
-      const voidPromise = new Promise(() => Promise.resolve(true));
-
-      botSendMessageSpy = spyOn(bot, 'sendMessage').and.returnValue(voidPromise);
+      botSendMessageSpy = spyOn(bot, 'sendMessage').and.callThrough();
     });
 
     it('should always indicate the parse mode is HTML', () => {
@@ -46,19 +48,115 @@ describe('Utils', () => {
       );
     });
 
-    it('should send the message as a reply', () => {
-      const optionsUsed = {
-        parse_mode: 'HTML',
-        reply_to_message_id: replyToMessageId,
-      };
+    describe('Reply', () => {
+      it('should send the message as a reply', () => {
+        const optionsUsed = {
+          parse_mode: 'HTML',
+          reply_to_message_id: replyToMessageId,
+        };
 
-      sendMessageHTML(bot, chatID, message, replyToMessageId);
+        sendMessageHTML(bot, chatID, message, replyToMessageId);
 
-      expect(botSendMessageSpy).toHaveBeenCalledWith(
-        jasmine.any(Number),
-        jasmine.any(String),
-        optionsUsed,
-      );
+        expect(botSendMessageSpy).toHaveBeenCalledWith(
+          jasmine.any(Number),
+          jasmine.any(String),
+          optionsUsed,
+        );
+      });
+    });
+
+    describe('Return', () => {
+      let sent$: Observable<TelegramBot.Message | any>;
+
+      beforeEach(() => {
+        sent$ = sendMessageHTML(bot, chatID, message);
+      });
+
+      it('should return an observable that emits the message when is sent', () => {
+        expect(sent$ instanceof Observable).toBeTruthy();
+      });
+
+      it('should return the msg sent', (done) => {
+        let messageSent: TelegramBot.Message;
+
+        sent$.subscribe({
+          next: (msg) => {
+            messageSent = msg;
+
+            expect(messageSent).not.toEqual(message);
+            expect(messageSent.chat.id).toEqual(chatID);
+          },
+          complete: () => done(),
+        });
+
+        bot.triggerMessageSent();
+      });
+    });
+
+    describe('Error Handling', () => {
+      let sent$: Observable<TelegramBot.Message | any>;
+
+      beforeEach(() => {
+        sent$ = sendMessageHTML(bot, chatID, message);
+      });
+
+      describe('Error 403', () => {
+        let triggered: boolean;
+        let subscription: Subscription;
+
+        beforeEach(async () => {
+          triggered = false;
+          subscription = sent$.subscribe(() => triggered = true);
+
+          bot.triggerMessageSentError403();
+
+          // Wait for completion or emit
+          await sent$.toPromise();
+        });
+
+        it('should trigger nothing', () => {
+          expect(triggered).toBeFalsy();
+        });
+
+        it('should close the observable', () => {
+          expect(subscription.closed).toBeTruthy();
+        });
+      });
+
+      describe('Any Error', () => {
+        let triggered: boolean;
+        let errorTriggered: boolean;
+
+        let subscription: Subscription;
+
+        beforeEach(async () => {
+          triggered = false;
+          errorTriggered = false;
+
+          subscription = sent$.pipe(
+            catchError((err) => {
+              errorTriggered = true;
+              return NEVER;
+            }),
+          )
+            .subscribe(() => triggered = true);
+
+          bot.triggerMessageSentErrorAny();
+
+          // Wait for completion or emit, need the catch, if it's not there
+          // the test is going to explode, the error is riced
+          // tslint:disable-next-line: no-empty
+          await sent$.toPromise().catch(() => { });
+        });
+
+        it('should not trigger any value on next', () => {
+          expect(triggered).toBeFalsy();
+        });
+
+        it('should throw an error', () => {
+          expect(errorTriggered).toBeTruthy();
+        });
+      });
     });
   });
 });

--- a/src/telegram-bot/features/stats/cron/cron.service.ts
+++ b/src/telegram-bot/features/stats/cron/cron.service.ts
@@ -6,7 +6,7 @@ import * as cron from 'node-cron';
 
 @Injectable()
 export class CronService {
-  // UTC 10 min passed midnight
+  // UTC 2pm hour
   public readonly cronExpression = '0 0 14 * * *';
 
   get cronAnnouncer(): Observable<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,10 +731,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@types/node@10.14.6":
-  version "10.14.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.6.tgz#9cbfcb62c50947217f4d88d4d274cc40c22625a9"
-  integrity sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==
+"@types/node@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
+  integrity sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Changed the `sendMessage` function to have more control over the errors

The error was described on #16 