### PR TITLE
fix: fix bindCallback return type when error

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,20 +1,26 @@
 import { Observable } from 'rxjs';
+import { isArray } from 'util';
 
 export const buildNPMLink = (slug: string) =>
   `https://www.npmjs.com/package/${slug}`;
 
-export type bindCallback_1A_2R<A1, R1, R2> = (a1: A1) => Observable<[R1, R2]>;
-export type bindCallback_3A_3R<A1, A2, A3, R1, R2, R3> = (a1: A1, a2: A2, a3: A3) => Observable<[R1, R2, R3]>;
+export type bindCallback_1A_2R<A1, R1, R2> = (
+  a1: A1,
+) => Observable<[null, R2] | R1>;
+export type bindCallback_3A_3R<A1, A2, A3, R1, R2, R3> = (
+  a1: A1,
+  a2: A2,
+  a3: A3,
+) => Observable<[null, R2, R3] | R1>;
 
-interface IDBResponse extends Array<any> {
-  [index: number]: any;
-  0: Error;
-}
+type IDBResponse<T> = [null, ...T[]];
 
-export function handleDBError([err, ...rest]: IDBResponse): any[] {
-  if (!!err) {
-    throw err;
+export function handleDBError<T>(dbResp: IDBResponse<T> | Error): T[] {
+  if (isArray(dbResp)) {
+    const [_, ...rest] = dbResp;
+
+    return rest;
+  } else {
+    throw dbResp;
   }
-
-  return rest;
 }

--- a/src/shared/users/repository/users.repository.spec.ts
+++ b/src/shared/users/repository/users.repository.spec.ts
@@ -25,7 +25,9 @@ describe('UsersRepository', () => {
     it('should create the database with the right options', () => {
       process.env.DATABASE_PATH = '/some/base/';
 
-      expect((Datastore as any).instance.databaseOptions.filename).toContain('users.db');
+      expect((Datastore as any).instance.databaseOptions.filename).toContain(
+        'users.db',
+      );
       expect((Datastore as any).instance.databaseOptions.autoload).toBeTruthy();
     });
 
@@ -40,7 +42,8 @@ describe('UsersRepository', () => {
   describe('Create User', () => {
     let userToCreate: User;
 
-    const createUser = (newUser: User) => repository.create(newUser).toPromise();
+    const createUser = (newUser: User) =>
+      repository.create(newUser).toPromise();
 
     beforeEach(() => {
       userToCreate = new User(12345);
@@ -67,8 +70,8 @@ describe('UsersRepository', () => {
         };
 
         spyOn(Datastore.prototype, 'insert').and.callFake(
-          (_, callback: (e, d) => void) => {
-            callback(error, _);
+          (_, callback: (e, d?) => void) => {
+            callback(error);
           },
         );
 
@@ -83,7 +86,7 @@ describe('UsersRepository', () => {
         expect(userCreated.chatId).toEqual(userToCreate.chatId);
       });
 
-      it('should throw an error when is different than \'uniqueViolated\'', async () => {
+      it('should throw an error when is different than "uniqueViolated"', async () => {
         const errorToThrow = mockInsertAndThrowError('runOutSpace');
         let errorThrown;
 
@@ -93,7 +96,7 @@ describe('UsersRepository', () => {
           errorThrown = err;
         }
 
-        expect(errorToThrow).toBe(errorThrown);
+        expect(errorThrown).toBe(errorToThrow);
       });
     });
   });
@@ -107,15 +110,16 @@ describe('UsersRepository', () => {
       chatId = 1234;
       randomUser = new User(chatId);
 
-      repository.getUser(chatId)
-        .subscribe((user) => (userFound = user));
+      repository.getUser(chatId).subscribe(user => (userFound = user));
       (Datastore as any).instance.triggerAction(randomUser.toJson());
     });
 
     it('should try find the user given the chatID', async () => {
       const expectedFind = { chatId };
 
-      expect((Datastore as any).instance.findOneParameter).toEqual(expectedFind);
+      expect((Datastore as any).instance.findOneParameter).toEqual(
+        expectedFind,
+      );
     });
 
     it('should return a instance of user', () => {
@@ -140,11 +144,9 @@ describe('UsersRepository', () => {
     });
 
     beforeEach(() => {
-      repository.getAllUsers()
-        .subscribe((users) => (usersFound = users));
+      repository.getAllUsers().subscribe(users => (usersFound = users));
 
-      const plainRandomUsers = randomUsers
-        .map((u) => classToPlain(u));
+      const plainRandomUsers = randomUsers.map(u => classToPlain(u));
 
       (Datastore as any).instance.triggerAction(plainRandomUsers);
     });
@@ -156,7 +158,7 @@ describe('UsersRepository', () => {
     });
 
     it('should return a instance of user', () => {
-      const allInstancesOfUser = usersFound.every((u) => u instanceof User);
+      const allInstancesOfUser = usersFound.every(u => u instanceof User);
 
       expect(allInstancesOfUser).toBeTruthy();
       expect(randomUsers).toEqual(usersFound);
@@ -173,14 +175,15 @@ describe('UsersRepository', () => {
       packToAdd = { npmSlug: 'angular' };
       randomUser = new User(chatId);
 
-      repository.addPackage(randomUser, packToAdd)
-        .subscribe();
+      repository.addPackage(randomUser, packToAdd).subscribe();
       (Datastore as any).instance.triggerAction();
     });
 
     it('should try to add a package given the user', () => {
       const expectedQuery = { chatId };
-      const expectedUpdate = { $set: { [`packages.${packToAdd.npmSlug}`]: packToAdd } };
+      const expectedUpdate = {
+        $set: { [`packages.${packToAdd.npmSlug}`]: packToAdd },
+      };
 
       let query: any;
       let update: any;

--- a/src/shared/users/repository/users.repository.ts
+++ b/src/shared/users/repository/users.repository.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 
 import Datastore = require('nedb');
 
-import { bindCallback_1A_2R, handleDBError, bindCallback_3A_3R } from '../../../common/utils';
+import {
+  bindCallback_1A_2R,
+  handleDBError,
+  bindCallback_3A_3R,
+} from '../../../common/utils';
 
 import { Observable, bindCallback, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -40,8 +44,8 @@ export class UsersRepository {
 
     return insert(user.toJson()).pipe(
       map(handleDBError),
-      map((rest) => rest[0]),
-      catchError<User, Observable<User>>(err => {
+      map(rest => rest[0]),
+      catchError(err => {
         if (err.errorType === 'uniqueViolated') {
           return of(user);
         }
@@ -65,7 +69,7 @@ export class UsersRepository {
 
     return findOne(query).pipe(
       map(handleDBError),
-      map((rest) => rest[0]),
+      map(rest => rest[0]),
       map((user: User) => plainToClass(User, user)),
     );
   }
@@ -77,7 +81,7 @@ export class UsersRepository {
 
     return findAll({}).pipe(
       map(handleDBError),
-      map((rest) => rest[0]),
+      map(rest => rest[0]),
       map((users: User[]) => plainToClass(User, users)),
     );
   }
@@ -88,18 +92,31 @@ export class UsersRepository {
    * @param user The user that adds the package
    * @param pack The package to add
    */
-  addPackage(user: User, pack: IPackage): Observable<any> {
+  addPackage(user: User, pack: IPackage) {
     const query = { chatId: user.chatId } as User;
     const updateCondition = {
       $set: { [`packages.${pack.npmSlug}`]: pack },
     };
 
-    const update = (bindCallback<any, any, Nedb.UpdateOptions, Error, number, boolean>(
-      this.db.update.bind(this.db),
-    ) as unknown) as bindCallback_3A_3R<any, any, Nedb.UpdateOptions, Error, number, boolean>;
+    const update = (bindCallback<
+      any,
+      any,
+      Nedb.UpdateOptions,
+      Error,
+      number,
+      boolean
+    >(this.db.update.bind(this.db)) as unknown) as bindCallback_3A_3R<
+      any,
+      any,
+      Nedb.UpdateOptions,
+      Error,
+      number,
+      boolean
+    >;
 
     return update(query, updateCondition, {}).pipe(
       map(handleDBError),
+      map(rest => rest[0]),
     );
   }
 }

--- a/src/shared/users/service/users.service.ts
+++ b/src/shared/users/service/users.service.ts
@@ -8,8 +8,7 @@ import { UsersRepository } from '../repository/users.repository';
 
 @Injectable()
 export class UsersService {
-
-  constructor(private usersRepository: UsersRepository) { }
+  constructor(private usersRepository: UsersRepository) {}
 
   create(user: User): Observable<User> {
     return this.usersRepository.create(user);
@@ -32,6 +31,7 @@ export class UsersService {
 
           return this.usersRepository.addPackage(user, pack).pipe(
             tap(() => user.addPackage(pack)),
+            map(() => user),
           );
         } else {
           return of(user);
@@ -40,7 +40,7 @@ export class UsersService {
     );
   }
 
-  getUser(chatId: number): Observable<User>  {
+  getUser(chatId: number): Observable<User> {
     return this.usersRepository.getUser(chatId);
   }
 

--- a/src/telegram-bot/features/stats/cron/__mocks__/cron.service.ts
+++ b/src/telegram-bot/features/stats/cron/__mocks__/cron.service.ts
@@ -1,5 +1,3 @@
-import { Injectable } from '@nestjs/common';
-
 import { Subject, Observable } from 'rxjs';
 
 import cronMock = require('../../../../../__mocks__/node-cron');


### PR DESCRIPTION
We got the types of the `bindCallback` bad defined when an error was thrown